### PR TITLE
+session_id +session_offset

### DIFF
--- a/ChildProject/projects.py
+++ b/ChildProject/projects.py
@@ -48,6 +48,8 @@ class ChildProject:
         IndexColumn(name = 'recording_device_type', description = 'lena, usb, olympus, babylogger (lowercase)', required = True, choices = ['lena', 'usb', 'olympus', 'babylogger']),
         IndexColumn(name = 'filename', description = 'the path to the file from the root of “recordings”), set to ‘NA’ if no valid recording available. It is unique (two recordings cannot point towards the same file).', required = True, filename = True, unique = True),
         IndexColumn(name = 'duration', description = 'duration of the audio', regex = r'(\d+(\.\d+)?)'),
+        IndexColumn(name = 'session_id', description = 'identifier of the recording session.'),
+        IndexColumn(name = 'session_offset', description = 'offset (in seconds) of the recording with respect to other recordings that are part of the same session. Each recording session is identified by their `session_id`.', regex = r'(\d+(\.\d+)?)'),
         IndexColumn(name = 'recording_device_id', description = 'unique ID of the recording device'),
         IndexColumn(name = 'experimenter', description = 'who collected the data (could be anonymized ID)'),
         IndexColumn(name = 'location_id', description = 'unique location ID -- can be specified at the level of the child (if children do not change locations)'),


### PR DESCRIPTION
# Description

Several devices can be recording at the same time in the same location. In this case, it is often needed to synchronise these devices. This can be achieved through more columns in the metadata.

# Progress

 - [x] tests
 - [x] documentation
 - [x] implementation
   - [x] session_id and session_offset columns
   
# Associated issues

#120 